### PR TITLE
Removed in-line comments

### DIFF
--- a/configurations/language-configuration.json
+++ b/configurations/language-configuration.json
@@ -1,7 +1,5 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "/*", "*/" ]
     },


### PR DESCRIPTION
In-line comments of the style `//` are not supported by CSS. PostCSS doesn't change this unless you add a plugin like postcss-comment-2 (https://github.com/nightwolfz/postcss-comment). Thus, I don't think this plugin ought to default to using this style.